### PR TITLE
chore: shift+space for switching input source guide in macOS monterey

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,43 @@ This message shows that your installation appears to be working correctly.
 ...
 ```
 
+### (Only MacOS) Monterey에서 shift+space 로 한/영 전환 안되는 문제
+- References: https://andrewpage.tistory.com/95
+
+1. plist 파일을 xml 형식으로 변경
+
+```bash
+$ plutil -convert xml1 /Library/Preferences/com.apple.symbolichotkeys.plist
+```
+
+2. `/Library/Preferences/com.apple.symbolichotkeys.plist` xml 문서를 수정
+
+```xml
+...
+        <key>61</key>
+        <dict>
+            <key>enabled</key>
+            <true/>
+            <key>value</key>
+            <dict>
+                <key>parameters</key>
+                <array>
+                    <integer>32</integer>
+                    <integer>49</integer>
+                    <integer>8519680</integer>  <!-- 여기 8519680 를 131072로 변경 -->
+                </array>
+                <key>type</key>
+                <string>standard</string>
+...
+```
+              
+3. 다시 원래의 plist binary 형태로 변환
+
+```bash
+$ plutil -convert binary1 /Library/Preferences/com.apple.symbolichotkeys.plist
+```
+
+4. macOS reboot
 
 ### (Only MacOS) Preferences Keyboard setting
 - Preferences - Keyboard - Adjust `Key Repeat`, `Delay Until Repeat`

--- a/README.md
+++ b/README.md
@@ -220,13 +220,18 @@ This message shows that your installation appears to be working correctly.
 ### (Only MacOS) Monterey에서 shift+space 로 한/영 전환 안되는 문제
 - References: https://andrewpage.tistory.com/95
 
-1. plist 파일을 xml 형식으로 변경
+1. 만일의 사태를 대비해 plist 파일을 백업
+```
+$ cp ~/Library/Preferences/com.apple.symbolichotkeys.plist ~/Library/Preferences/com.apple.symbolichotkeys.plist.backup
+```
+
+2. plist 파일을 xml 형식으로 변경
 
 ```bash
 $ plutil -convert xml1 ~/Library/Preferences/com.apple.symbolichotkeys.plist
 ```
 
-2. `~/Library/Preferences/com.apple.symbolichotkeys.plist` xml 문서를 수정
+3. `~/Library/Preferences/com.apple.symbolichotkeys.plist` xml 문서를 수정
 
 ```xml
 ...
@@ -247,13 +252,13 @@ $ plutil -convert xml1 ~/Library/Preferences/com.apple.symbolichotkeys.plist
 ...
 ```
               
-3. 다시 원래의 plist binary 형태로 변환
+4. 다시 원래의 plist binary 형태로 변환
 
 ```bash
 $ plutil -convert binary1 ~/Library/Preferences/com.apple.symbolichotkeys.plist
 ```
 
-4. macOS reboot
+5. macOS reboot
 
 ### (Only MacOS) Preferences Keyboard setting
 - Preferences - Keyboard - Adjust `Key Repeat`, `Delay Until Repeat`

--- a/README.md
+++ b/README.md
@@ -223,10 +223,10 @@ This message shows that your installation appears to be working correctly.
 1. plist 파일을 xml 형식으로 변경
 
 ```bash
-$ plutil -convert xml1 /Library/Preferences/com.apple.symbolichotkeys.plist
+$ plutil -convert xml1 ~/Library/Preferences/com.apple.symbolichotkeys.plist
 ```
 
-2. `/Library/Preferences/com.apple.symbolichotkeys.plist` xml 문서를 수정
+2. `~/Library/Preferences/com.apple.symbolichotkeys.plist` xml 문서를 수정
 
 ```xml
 ...
@@ -250,7 +250,7 @@ $ plutil -convert xml1 /Library/Preferences/com.apple.symbolichotkeys.plist
 3. 다시 원래의 plist binary 형태로 변환
 
 ```bash
-$ plutil -convert binary1 /Library/Preferences/com.apple.symbolichotkeys.plist
+$ plutil -convert binary1 ~/Library/Preferences/com.apple.symbolichotkeys.plist
 ```
 
 4. macOS reboot

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ $ plutil -convert xml1 ~/Library/Preferences/com.apple.symbolichotkeys.plist
 
 ```xml
 ...
-        <key>61</key>
+        <key>61</key>              <!-- 여기 key: 61 을 찾아서, -->
         <dict>
             <key>enabled</key>
             <true/>
@@ -240,7 +240,7 @@ $ plutil -convert xml1 ~/Library/Preferences/com.apple.symbolichotkeys.plist
                 <array>
                     <integer>32</integer>
                     <integer>49</integer>
-                    <integer>8519680</integer>  <!-- 여기 8519680 를 131072로 변경 -->
+                    <integer>8519680</integer>  <!-- 3번째 integer 값을 131072로 변경 -->
                 </array>
                 <key>type</key>
                 <string>standard</string>


### PR DESCRIPTION
- macOS Monterey에서 shift+space로 한영 전환이 안되는 문제가 있는데, plist 파일을 수정하여 해결하는 가이드 추가.
- 출처: https://andrewpage.tistory.com/95